### PR TITLE
Add block for "Attribution" tab panel on single photos

### DIFF
--- a/source/wp-content/themes/wporg-photos-2024/functions.php
+++ b/source/wp-content/themes/wporg-photos-2024/functions.php
@@ -8,6 +8,7 @@ require_once( __DIR__ . '/inc/block-config.php' );
 
 // Block files
 require_once( __DIR__ . '/src/meta-list/index.php' );
+require_once( __DIR__ . '/src/photo-attribution/index.php' );
 
 // Actions & filters.
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );

--- a/source/wp-content/themes/wporg-photos-2024/patterns/single.php
+++ b/source/wp-content/themes/wporg-photos-2024/patterns/single.php
@@ -82,9 +82,7 @@
 		<p>Photo attribution is not necessary, but appreciated. If you'd like to give credit to the photographer, feel free to use this text:</p>
 		<!-- /wp:paragraph -->
 
-		<!-- wp:paragraph -->
-		<p>[block]</p>
-		<!-- /wp:paragraph -->
+		<!-- wp:wporg/photo-attribution /-->
 	</div>
 	<!-- /wp:group -->
 

--- a/source/wp-content/themes/wporg-photos-2024/src/photo-attribution/block.json
+++ b/source/wp-content/themes/wporg-photos-2024/src/photo-attribution/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "wporg/photo-attribution",
 	"version": "0.1.0",
 	"title": "Photo Attribution",

--- a/source/wp-content/themes/wporg-photos-2024/src/photo-attribution/block.json
+++ b/source/wp-content/themes/wporg-photos-2024/src/photo-attribution/block.json
@@ -1,0 +1,20 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wporg/photo-attribution",
+	"version": "0.1.0",
+	"title": "Photo Attribution",
+	"category": "design",
+	"icon": "",
+	"description": "Display photo attribution information.",
+	"textdomain": "wporg",
+	"supports": {
+		"html": false,
+		"interactivity": true
+	},
+	"usesContext": [ "postId", "postType" ],
+	"editorScript": "file:./index.js",
+	"style": "file:./style-index.css",
+	"viewScriptModule": "file:./view.js",
+	"render": "file:./render.php"
+}

--- a/source/wp-content/themes/wporg-photos-2024/src/photo-attribution/index.js
+++ b/source/wp-content/themes/wporg-photos-2024/src/photo-attribution/index.js
@@ -1,0 +1,32 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import ServerSideRender from '@wordpress/server-side-render';
+import { useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import './style.scss';
+
+function Edit( { name, attributes, context } ) {
+	const blockProps = useBlockProps();
+	const { postId } = context;
+	return (
+		<div { ...blockProps }>
+			<ServerSideRender
+				block={ name }
+				attributes={ attributes }
+				skipBlockSupportAttributes
+				urlQueryArgs={ { post_id: postId } }
+			/>
+		</div>
+	);
+}
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => null,
+} );

--- a/source/wp-content/themes/wporg-photos-2024/src/photo-attribution/index.php
+++ b/source/wp-content/themes/wporg-photos-2024/src/photo-attribution/index.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Block Name: Photo Attribution
+ * Description: Display photo attribution information.
+ *
+ * @package wporg
+ */
+
+ namespace WordPressdotorg\Theme\Photo_Directory_2024\Photo_Attribution_Block;
+
+defined( 'WPINC' ) || die();
+
+add_action( 'init', __NAMESPACE__ . '\init' );
+
+/**
+ * Register the block.
+ */
+function init() {
+	register_block_type( __DIR__ . '/../../build/photo-attribution' );
+}

--- a/source/wp-content/themes/wporg-photos-2024/src/photo-attribution/render.php
+++ b/source/wp-content/themes/wporg-photos-2024/src/photo-attribution/render.php
@@ -63,6 +63,7 @@ $id_prefix = wp_unique_id( 'attr-' );
 			id="<?php echo esc_attr( $id_prefix . '-tab-rtf' ); ?>"
 			data-wp-bind--tabindex="state.tabIndex"
 			data-wp-on--click="actions.openTab"
+			data-wp-on--keydown="actions.onKeyDown"
 		><?php esc_html_e( 'Rich Text', 'wporg-photos' ); ?></button>
 		<button
 			class="wporg-photo-attribution__tab"
@@ -73,6 +74,7 @@ $id_prefix = wp_unique_id( 'attr-' );
 			id="<?php echo esc_attr( $id_prefix . '-tab-html' ); ?>"
 			data-wp-bind--tabindex="state.tabIndex"
 			data-wp-on--click="actions.openTab"
+			data-wp-on--keydown="actions.onKeyDown"
 		><?php esc_html_e( 'HTML', 'wporg-photos' ); ?></button>
 		<button
 			class="wporg-photo-attribution__tab"
@@ -83,6 +85,7 @@ $id_prefix = wp_unique_id( 'attr-' );
 			id="<?php echo esc_attr( $id_prefix . '-tab-txt' ); ?>"
 			data-wp-bind--tabindex="state.tabIndex"
 			data-wp-on--click="actions.openTab"
+			data-wp-on--keydown="actions.onKeyDown"
 		><?php esc_html_e( 'Plain text', 'wporg-photos' ); ?></button>
 	</div>
 	<div

--- a/source/wp-content/themes/wporg-photos-2024/src/photo-attribution/render.php
+++ b/source/wp-content/themes/wporg-photos-2024/src/photo-attribution/render.php
@@ -38,7 +38,7 @@ $txt_content = sprintf(
 $init_state = [
 	'i18n' => [
 		'copySuccess' => __( 'Copied!', 'wporg-photos' ),
-		'copyDefault' => __( 'Copy to clipboard', 'wporg-photos' ),
+		'copyDefault' => __( 'Copy', 'wporg-photos' ),
 	],
 	'tab' => 'rtf',
 ];
@@ -126,6 +126,6 @@ $id_prefix = wp_unique_id( 'attr-' );
 			class="wp-block-button__link wp-element-button"
 			data-wp-on--click="actions.copyText"
 			data-wp-text="state.buttonLabel"
-		><?php esc_html_e( 'Copy to clipboard', 'wporg-photos' ); ?></button>
+		><?php esc_html_e( 'Copy', 'wporg-photos' ); ?></button>
 	</div>
 </div>

--- a/source/wp-content/themes/wporg-photos-2024/src/photo-attribution/render.php
+++ b/source/wp-content/themes/wporg-photos-2024/src/photo-attribution/render.php
@@ -1,0 +1,128 @@
+<?php
+
+if ( ! $block->context['postId'] ) {
+	return '';
+}
+
+$photo_post = get_post( $block->context['postId'] );
+if ( ! $photo_post ) {
+	return '';
+}
+
+$rtf_content = sprintf(
+	/* translators: 1: URL to CC0 license, 2: URL to photo's page, 3: URL to contributor's profile, 4: Contributor's display name, 5: URL to Photo Directory. */
+	__( '<a href="%1$s">CC0</a> licensed <a href="%2$s">photo</a> by <a href="%3$s">%4$s</a> from the <a href="%5$s">WordPress Photo Directory</a>.', 'wporg-photos' ),
+	'https://creativecommons.org/share-your-work/public-domain/cc0/',
+	esc_url( get_the_permalink( $photo_post->ID ) ),
+	esc_url( get_author_posts_url( get_the_author_meta( 'ID', $photo_post->post_author ) ) ),
+	esc_html( get_the_author_meta( 'display_name', $photo_post->post_author ) ),
+	esc_url( home_url( '/' ) )
+);
+$html_content = sprintf(
+	/* translators: 1: URL to CC0 license, 2: URL to photo's page, 3: URL to contributor's profile, 4: Contributor's display name, 5: URL to Photo Directory. */
+	htmlentities( '<p class="attribution">' . __( '<a href="%1$s">CC0</a> licensed <a href="%2$s">photo</a> by <a href="%3$s">%4$s</a> from the <a href="%5$s">WordPress Photo Directory</a>.', 'wporg-photos' ) . '</p>' ),
+	'https://creativecommons.org/share-your-work/public-domain/cc0/',
+	esc_url( get_the_permalink( $photo_post->ID ) ),
+	esc_url( get_author_posts_url( get_the_author_meta( 'ID', $photo_post->post_author ) ) ),
+	esc_html( get_the_author_meta( 'display_name', $photo_post->post_author ) ),
+	esc_url( home_url( '/' ) )
+);
+$txt_content = sprintf(
+	/* translators: 1: Contributor's display name, 4: URL to photo's page. */
+	__( 'CC0 licensed photo by %1$s from the WordPress Photo Directory: %2$s', 'wporg-photos' ),
+	esc_html( get_the_author_meta( 'display_name', $photo_post->post_author ) ),
+	esc_url( get_the_permalink( $photo_post->ID ) ),
+);
+
+// Initial state to pass to Interactivity API.
+$init_state = [
+	'i18n' => [
+		'copySuccess' => __( 'Copied!', 'wporg-photos' ),
+		'copyDefault' => __( 'Copy to clipboard', 'wporg-photos' ),
+	],
+	'tab' => 'rtf',
+];
+
+$id_prefix = wp_unique_id( 'attr-' );
+
+?>
+<div
+	<?php echo get_block_wrapper_attributes();  // phpcs:ignore ?>
+	data-wp-interactive="wporg/photos/photo-attribution"
+	<?php echo wp_interactivity_data_wp_context( $init_state );  // phpcs:ignore ?>
+	data-wp-on-document--copy="callbacks.copyListener"
+	data-wp-class--is-loaded="state.isLoaded"
+>
+	<div class="wporg-photo-attribution__tablist" role="tablist" aria-label="<?php esc_attr_e( 'Attribution options', 'wporg-photos' ); ?>">
+		<button
+			class="wporg-photo-attribution__tab"
+			role="tab"
+			data-tab="rtf"
+			data-wp-bind--aria-selected="state.isCurrentTab"
+			aria-controls="<?php echo esc_attr( $id_prefix . '-panel-rtf' ); ?>"
+			id="<?php echo esc_attr( $id_prefix . '-tab-rtf' ); ?>"
+			data-wp-bind--tabindex="state.tabIndex"
+			data-wp-on--click="actions.openTab"
+		><?php esc_html_e( 'Rich Text', 'wporg-photos' ); ?></button>
+		<button
+			class="wporg-photo-attribution__tab"
+			role="tab"
+			data-tab="html"
+			data-wp-bind--aria-selected="state.isCurrentTab"
+			aria-controls="<?php echo esc_attr( $id_prefix . '-panel-html' ); ?>"
+			id="<?php echo esc_attr( $id_prefix . '-tab-html' ); ?>"
+			data-wp-bind--tabindex="state.tabIndex"
+			data-wp-on--click="actions.openTab"
+		><?php esc_html_e( 'HTML', 'wporg-photos' ); ?></button>
+		<button
+			class="wporg-photo-attribution__tab"
+			role="tab"
+			data-tab="txt"
+			data-wp-bind--aria-selected="state.isCurrentTab"
+			aria-controls="<?php echo esc_attr( $id_prefix . '-panel-txt' ); ?>"
+			id="<?php echo esc_attr( $id_prefix . '-tab-txt' ); ?>"
+			data-wp-bind--tabindex="state.tabIndex"
+			data-wp-on--click="actions.openTab"
+		><?php esc_html_e( 'Plain text', 'wporg-photos' ); ?></button>
+	</div>
+	<div
+		class="wporg-photo-attribution__tabpanel"
+		id="<?php echo esc_attr( $id_prefix . '-panel-rtf' ); ?>"
+		role="tabpanel"
+		data-tab="rtf"
+		tabindex="0"
+		aria-labelledby="<?php echo esc_attr( $id_prefix . '-tab-rtf' ); ?>"
+		data-wp-bind--hidden="!state.isCurrentTab"
+	>
+		<?php echo $rtf_content; // phpcs:ignore ?>
+	</div>
+	<div 
+		class="wporg-photo-attribution__tabpanel"
+		id="<?php echo esc_attr( $id_prefix . '-panel-html' ); ?>"
+		role="tabpanel"
+		data-tab="html"
+		tabindex="0"
+		aria-labelledby="<?php echo esc_attr( $id_prefix . '-tab-html' ); ?>"
+		data-wp-bind--hidden="!state.isCurrentTab"
+	>
+		<?php echo $html_content; // phpcs:ignore ?>
+	</div>
+	<div
+		class="wporg-photo-attribution__tabpanel"
+		id="<?php echo esc_attr( $id_prefix . '-panel-txt' ); ?>"
+		role="tabpanel"
+		data-tab="txt"
+		tabindex="0"
+		aria-labelledby="<?php echo esc_attr( $id_prefix . '-tab-txt' ); ?>"
+		data-wp-bind--hidden="!state.isCurrentTab"
+	>
+		<?php echo $txt_content; // phpcs:ignore ?>
+	</div>
+	<div class="wporg-photo-attribution__button-copy wp-block-button is-small">
+		<button
+			class="wp-block-button__link wp-element-button"
+			data-wp-on--click="actions.copyText"
+			data-wp-text="state.buttonLabel"
+		><?php esc_html_e( 'Copy to clipboard', 'wporg-photos' ); ?></button>
+	</div>
+</div>

--- a/source/wp-content/themes/wporg-photos-2024/src/photo-attribution/style.scss
+++ b/source/wp-content/themes/wporg-photos-2024/src/photo-attribution/style.scss
@@ -36,6 +36,10 @@
 	border-width: 1px 1px 0;
 	border-style: solid;
 	border-color: var(--wp--preset--color--light-grey-1);
+
+	&[data-tab="html"] {
+		font-family: var(--wp--preset--font-family--monospace);
+	}
 }
 
 .wporg-photo-attribution__button-copy {

--- a/source/wp-content/themes/wporg-photos-2024/src/photo-attribution/style.scss
+++ b/source/wp-content/themes/wporg-photos-2024/src/photo-attribution/style.scss
@@ -1,0 +1,46 @@
+.wp-block-wporg-photo-attribution:not(.is-loaded) {
+	// Prevent flashing content before the interactivity API loads in.
+	.wporg-photo-attribution__tabpanel:not([data-tab="rtf"]),
+	.wporg-photo-attribution__button-copy {
+		display: none;
+	}
+}
+
+.wporg-photo-attribution__tablist {
+	display: flex;
+	flex-wrap: nowrap;
+	gap: 2px; // Just enough space to prevent cutting off the outline.
+}
+
+.wporg-photo-attribution__tab {
+	padding: var(--wp--preset--spacing--10) var(--wp--preset--spacing--20);
+	background-color: transparent;
+	border: 1px solid transparent;
+
+	&:hover {
+		border-bottom-color: var(--wp--preset--color--light-grey-1);
+		background-color: var(--wp--preset--color--light-grey-2) !important;
+	}
+
+	&[aria-selected="true"] {
+		background-color: var(--wp--preset--color--white);
+		border-color: var(--wp--preset--color--light-grey-1);
+		border-bottom-color: transparent;
+		z-index: 1;
+	}
+}
+
+.wporg-photo-attribution__tabpanel {
+	margin-top: -1px;
+	padding: var(--wp--preset--spacing--20);
+	border-width: 1px 1px 0;
+	border-style: solid;
+	border-color: var(--wp--preset--color--light-grey-1);
+}
+
+.wporg-photo-attribution__button-copy {
+	padding: 0 var(--wp--preset--spacing--20) var(--wp--preset--spacing--20);
+	border-width: 0 1px 1px;
+	border-style: solid;
+	border-color: var(--wp--preset--color--light-grey-1);
+}

--- a/source/wp-content/themes/wporg-photos-2024/src/photo-attribution/view.js
+++ b/source/wp-content/themes/wporg-photos-2024/src/photo-attribution/view.js
@@ -1,0 +1,66 @@
+/**
+ * WordPress dependencies
+ */
+import { getContext, getElement, store, withScope } from '@wordpress/interactivity';
+
+const { state } = store( 'wporg/photos/photo-attribution', {
+	state: {
+		get isCurrentTab() {
+			const { tab } = getContext();
+			const { attributes } = getElement();
+			return tab === attributes[ 'data-tab' ];
+		},
+		get buttonLabel() {
+			const { i18n } = getContext();
+			return state.copied ? i18n.copySuccess : i18n.copyDefault;
+		},
+		get tabIndex() {
+			const { tab } = getContext();
+			const { attributes } = getElement();
+			return tab === attributes[ 'data-tab' ] ? 0 : -1;
+		},
+		isLoaded: true,
+		copied: false,
+	},
+	actions: {
+		openTab: () => {
+			const context = getContext();
+			const { attributes } = getElement();
+			context.tab = attributes[ 'data-tab' ];
+			state.copied = false;
+		},
+		copyText: () => {
+			document.execCommand( 'copy' );
+		},
+	},
+	callbacks: {
+		copyListener: ( event ) => {
+			event.preventDefault();
+			const { tab } = getContext();
+			const { ref } = getElement();
+			const container = ref.closest( '.wp-block-wporg-photo-attribution' );
+
+			// Get the active tab.
+			const attribution = container.querySelector( '.wporg-photo-attribution__tabpanel:not([hidden])' );
+			let content = attribution.innerHTML.trim();
+			if ( 'html' === tab ) {
+				// Decode HTML entities.
+				const textarea = document.createElement( 'textarea' );
+				textarea.innerHTML = content;
+				content = textarea.value;
+			}
+
+			if ( 'rtf' === tab ) {
+				event.clipboardData.setData( 'text/html', content );
+			}
+
+			event.clipboardData.setData( 'text/plain', content );
+
+			state.copied = true;
+			setTimeout(
+				withScope( () => ( state.copied = false ) ),
+				10000
+			);
+		},
+	},
+} );

--- a/source/wp-content/themes/wporg-photos-2024/src/photo-attribution/view.js
+++ b/source/wp-content/themes/wporg-photos-2024/src/photo-attribution/view.js
@@ -3,6 +3,9 @@
  */
 import { getContext, getElement, store, withScope } from '@wordpress/interactivity';
 
+// List of tabs in order, used for arrow key navigation.
+const TABLIST = [ 'rtf', 'html', 'txt' ];
+
 const { state } = store( 'wporg/photos/photo-attribution', {
 	state: {
 		get isCurrentTab() {
@@ -28,6 +31,28 @@ const { state } = store( 'wporg/photos/photo-attribution', {
 			const { attributes } = getElement();
 			context.tab = attributes[ 'data-tab' ];
 			state.copied = false;
+		},
+		onKeyDown( event ) {
+			const context = getContext();
+			const { ref } = getElement();
+			// Cycle through the tab list with arrow keys.
+			const current = TABLIST.indexOf( context.tab );
+			const max = TABLIST.length;
+			if ( 'ArrowLeft' === event.code ) {
+				const i = current === 0 ? max - 1 : current - 1;
+				context.tab = TABLIST[ i ];
+			} else if ( 'ArrowRight' === event.code ) {
+				const i = current === max - 1 ? 0 : current + 1;
+				context.tab = TABLIST[ i ];
+			} else {
+				return;
+			}
+			// Move the tab focus to the just-selected button.
+			const container = ref.closest( '.wp-block-wporg-photo-attribution' );
+			const button = container.querySelector( `.wporg-photo-attribution__tab[data-tab="${ context.tab }"]` );
+			if ( button ) {
+				button.focus();
+			}
 		},
 		copyText: () => {
 			document.execCommand( 'copy' );


### PR DESCRIPTION
Fixes #8 — This adds a new block to render out the "Attribution" section, which is styled as a set of tabs for copyable attributions in Rich text, HTML, and Plain text formats. This renders out a [tablist](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tablist_role), tabs, and tabpanels, with the expected aria attributes and keyboard interactions. After the tablist is the "Copy" button, which will copy the selected format to the clipboard.

Note: Only the default state/rich text format was designed in Figma, so I've used my own judgement for the other tabs + interactive states (hover & focus for tabs). What do you think @WordPress/meta-design ?

**Screenshots**

![single-photo](https://github.com/user-attachments/assets/019f2af5-7a76-417d-aaa8-be2faa15cec5)

HTML attribution

![photo-attr-html](https://github.com/user-attachments/assets/a969fd00-1f9e-40b6-b532-c80260b91c91)

Plain text attribution

![photo-attr-txt](https://github.com/user-attachments/assets/f8923ec8-8755-42a4-b8d8-9dc1eee635d3)

Interactive styles

| Hover state | Focus state |
|---|---|
| ![photo-attr-hover](https://github.com/user-attachments/assets/47cda914-3910-4ad1-ab0a-fe0c6a58b373) | ![photo-attr-focus](https://github.com/user-attachments/assets/917e1e3d-0a02-4b76-8599-50dc2e67f0c1) |

