### PR TITLE
Submissions: Use a plain table for listing pending submissions

### DIFF
--- a/source/wp-content/themes/wporg-photos-2024/src/style/_submission.scss
+++ b/source/wp-content/themes/wporg-photos-2024/src/style/_submission.scss
@@ -1,13 +1,15 @@
-.wporg-submissions-pending__list {
-	> div + div {
-		border-top: 0 !important;
-		border-top-right-radius: 0 !important;
-		border-top-left-radius: 0 !important;
+.wp-block-table.wporg-submissions-pending__list {
+	thead {
+		border-bottom: none;
 	}
 
-	> div:not(:last-child) {
-		border-bottom-right-radius: 0 !important;
-		border-bottom-left-radius: 0 !important;
+	th {
+		font-weight: 700;
+	}
+
+	td,
+	th {
+		padding-block: var(--wp--preset--spacing--10);
 	}
 }
 

--- a/source/wp-content/themes/wporg-photos-2024/src/style/_submission.scss
+++ b/source/wp-content/themes/wporg-photos-2024/src/style/_submission.scss
@@ -11,6 +11,39 @@
 	th {
 		padding-block: var(--wp--preset--spacing--10);
 	}
+
+	.is-inline-label {
+		display: none;
+	}
+
+	@media (max-width: 600px) {
+		thead {
+			display: none;
+		}
+
+		tr {
+			display: block;
+			border-width: 1px 1px 0;
+			border-style: solid;
+			border-color: var(--wp--preset--color--light-grey-1);
+			padding-block: 5px;
+
+			&:last-of-type {
+				border-bottom-width: 1px;
+			}
+		}
+
+		td {
+			display: block;
+			border: 0;
+			padding-block: 5px;
+		}
+
+		.is-inline-label {
+			display: initial;
+			font-weight: 700;
+		}
+	}
 }
 
 #wporg-photo-upload {

--- a/source/wp-content/themes/wporg-photos-2024/view/submissions-pending.php
+++ b/source/wp-content/themes/wporg-photos-2024/view/submissions-pending.php
@@ -48,9 +48,18 @@ $details = array(
 			$image_caption = get_the_content( null, false, $photo_post ) ?: __( '(none provided)', 'wporg-photos' );
 			?>
 			<tr>
-				<td><?php echo esc_html( $image_title ); ?></td>
-				<td><?php echo esc_html( $image_date ); ?></td>
-				<td><?php echo esc_html( $image_caption ); ?></td>
+				<td>
+					<span class="is-inline-label"><?php esc_html_e( 'File:', 'wporg-photos' ); ?></span>
+					<?php echo esc_html( $image_title ); ?>
+				</td>
+				<td>
+					<span class="is-inline-label"><?php esc_html_e( 'Submission date:', 'wporg-photos' ); ?></span>
+					<?php echo esc_html( $image_date ); ?>
+				</td>
+				<td>
+					<span class="is-inline-label"><?php esc_html_e( 'Caption:', 'wporg-photos' ); ?></span>
+					<?php echo esc_html( $image_caption ); ?>
+				</td>
 			</tr>
 		<?php endforeach; ?>
 		</tbody>

--- a/source/wp-content/themes/wporg-photos-2024/view/submissions-pending.php
+++ b/source/wp-content/themes/wporg-photos-2024/view/submissions-pending.php
@@ -30,39 +30,30 @@ $details = array(
 <p><?php echo wp_kses_post( implode( ' ', $details ) ); ?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:group {"className":"wporg-submissions-pending__list","style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group wporg-submissions-pending__list">
-	<?php
-	foreach ( $pending as $photo_post ) :
-		$image_id = get_post_thumbnail_id( $photo_post );
-		$image_url = get_the_post_thumbnail_url( $photo_post->ID, 'medium_large' );
-		$image_title = get_post_meta( $photo_post->ID, Registrations::get_meta_key( 'original_filename' ), true ) ?: __( '(unknown)', 'wporg-photos' );
-		$image_date = get_the_date( 'Y-m-d', $photo_post );
-		$image_caption = get_the_content( null, false, $photo_post ) ?: __( '(none provided)', 'wporg-photos' );
-		?>
-		<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20","right":"var:preset|spacing|20"},"blockGap":"var:preset|spacing|30"},"border":{"style":"solid","width":"1px","color":"#d9d9d9","radius":"2px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-		<div class="wp-block-group has-border-color" style="border-color:#d9d9d9;border-style:solid;border-width:1px;border-radius:2px;padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20)">
-			<!-- wp:image {"id":<?php echo intval( $image_id ); ?>,"width":"180px","aspectRatio":"16/9","scale":"cover","sizeSlug":"medium","linkDestination":"none"} -->
-			<figure class="wp-block-image size-medium is-resized"><img src="<?php echo esc_url( $image_url ); ?>" alt="<?php esc_attr_e( 'View the photo.', 'wporg-photos' ); ?>" class="wp-image-<?php echo intval( $image_id ); ?>" style="aspect-ratio:16/9;object-fit:cover;width:180px"/></figure>
-			<!-- /wp:image -->
-
-			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-			<div class="wp-block-group">
-				<!-- wp:paragraph {"className":"is-style-short-text"} -->
-				<p class="is-style-short-text"><strong><?php esc_html_e( 'File:', 'wporg-photos' ); ?></strong> <?php echo esc_html( $image_title ); ?></p>
-				<!-- /wp:paragraph -->
-
-				<!-- wp:paragraph {"className":"is-style-short-text"} -->
-				<p class="is-style-short-text"><strong><?php esc_html_e( 'Submission date:', 'wporg-photos' ); ?></strong> <?php echo esc_html( $image_date ); ?></p>
-				<!-- /wp:paragraph -->
-
-				<!-- wp:paragraph {"className":"is-style-short-text"} -->
-				<p class="is-style-short-text"><strong><?php esc_html_e( 'Caption:', 'wporg-photos' ); ?></strong> <?php echo esc_html( $image_caption ); ?></p>
-				<!-- /wp:paragraph -->
-			</div>
-			<!-- /wp:group -->
-		</div>
-		<!-- /wp:group -->
-	<?php endforeach; ?>
-</div>
-<!-- /wp:group -->
+<!-- wp:table {"hasFixedLayout":alse,"className":"wporg-submissions-pending__list","fontSize":"small"} -->
+<figure class="wp-block-table has-small-font-size wporg-submissions-pending__list">
+	<table>
+		<thead><tr>
+			<th><?php esc_html_e( 'File', 'wporg-photos' ); ?></th>
+			<th><?php esc_html_e( 'Submission date', 'wporg-photos' ); ?></th>
+			<th><?php esc_html_e( 'Caption', 'wporg-photos' ); ?></th>
+		</tr></thead>
+		<tbody>
+		<?php
+		foreach ( $pending as $photo_post ) :
+			$image_id = get_post_thumbnail_id( $photo_post );
+			$image_url = get_the_post_thumbnail_url( $photo_post->ID, 'medium_large' );
+			$image_title = get_post_meta( $photo_post->ID, Registrations::get_meta_key( 'original_filename' ), true ) ?: __( '(unknown)', 'wporg-photos' );
+			$image_date = get_the_date( 'Y-m-d', $photo_post );
+			$image_caption = get_the_content( null, false, $photo_post ) ?: __( '(none provided)', 'wporg-photos' );
+			?>
+			<tr>
+				<td><?php echo esc_html( $image_title ); ?></td>
+				<td><?php echo esc_html( $image_date ); ?></td>
+				<td><?php echo esc_html( $image_caption ); ?></td>
+			</tr>
+		<?php endforeach; ?>
+		</tbody>
+	</table>
+</figure>
+<!-- /wp:table -->


### PR DESCRIPTION
Fixes WordPress/wporg-main-2022#16 — This swaps the "pending list" with photo thumbnail with a plain table, no photo.

**Screenshots**

![submission-page](https://github.com/user-attachments/assets/9f0ff911-aab0-4d41-80ee-c2e2be068d8b)

On small screens, the default table behavior is to scroll. Does this work, or should I try to add some CSS to switch to a single-column display?

![submissions-small](https://github.com/user-attachments/assets/cf869371-134e-48a1-a06d-b692d38cef59)
