### PR TITLE
Style: Use inter font size properties for heading sizes.

### DIFF
--- a/source/wp-content/themes/wporg-photos-2024/patterns/footer.php
+++ b/source/wp-content/themes/wporg-photos-2024/patterns/footer.php
@@ -12,8 +12,8 @@
 	<div class="wp-block-columns alignwide">
 		<!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}},"border":{"right":{"color":"var:preset|color|white-opacity-15","style":"solid","width":"1px"}}}} -->
 		<div class="wp-block-column" style="border-right-color:var(--wp--preset--color--white-opacity-15);border-right-style:solid;border-right-width:1px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--40)">
-			<!-- wp:heading {"fontSize":"large"} -->
-			<h2 class="wp-block-heading has-large-font-size"><?php esc_html_e( 'Contribute', 'wporg-photos' ); ?></h2>
+			<!-- wp:heading {"fontSize":"heading-5"} -->
+			<h2 class="wp-block-heading has-heading-5-font-size"><?php esc_html_e( 'Contribute', 'wporg-photos' ); ?></h2>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"className":"is-style-short-text"} -->
@@ -33,8 +33,8 @@
 
 		<!-- wp:column {"className":"is-style-short-text","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}}} -->
 		<div class="wp-block-column is-style-short-text" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--edge-space)">
-			<!-- wp:heading {"fontSize":"large"} -->
-			<h2 class="wp-block-heading has-large-font-size"><?php esc_html_e( 'License', 'wporg-photos' ); ?></h2>
+			<!-- wp:heading {"fontSize":"heading-5"} -->
+			<h2 class="wp-block-heading has-heading-5-font-size"><?php esc_html_e( 'License', 'wporg-photos' ); ?></h2>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"className":"is-style-short-text"} -->
@@ -55,8 +55,8 @@
 
 		<!-- wp:column {"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}},"border":{"left":{"color":"var:preset|color|white-opacity-15","style":"solid","width":"1px"}}}} -->
 		<div class="wp-block-column" style="border-left-color:var(--wp--preset--color--white-opacity-15);border-left-style:solid;border-left-width:1px;padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--edge-space)">
-			<!-- wp:heading {"fontSize":"large"} -->
-			<h2 class="wp-block-heading has-large-font-size"><?php esc_html_e( 'FAQ', 'wporg-photos' ); ?></h2>
+			<!-- wp:heading {"fontSize":"heading-5"} -->
+			<h2 class="wp-block-heading has-heading-5-font-size"><?php esc_html_e( 'FAQ', 'wporg-photos' ); ?></h2>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"className":"is-style-short-text"} -->

--- a/source/wp-content/themes/wporg-photos-2024/patterns/user.php
+++ b/source/wp-content/themes/wporg-photos-2024/patterns/user.php
@@ -12,8 +12,8 @@
 
 	<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 	<div class="wp-block-group">
-		<!-- wp:heading {"level":1,"fontSize":"heading-3","metadata":{"bindings":{"content":{"source":"wporg-photos/user-name"}}}} -->
-		<h1 class="wp-block-heading has-heading-3-font-size">Username</h1>
+		<!-- wp:heading {"level":1,"metadata":{"bindings":{"content":{"source":"wporg-photos/user-name"}}}} -->
+		<h1 class="wp-block-heading">Username</h1>
 		<!-- /wp:heading -->
 
 		<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"wporg-photos/user-link"}}}} -->

--- a/source/wp-content/themes/wporg-photos-2024/src/style/_single-photo.scss
+++ b/source/wp-content/themes/wporg-photos-2024/src/style/_single-photo.scss
@@ -1,6 +1,6 @@
 /* Style the "Alt text" label. */
 .wporg-alt-text-label {
-	font-weight: 700;
+	font-weight: 600;
 	user-select: none;
 }
 

--- a/source/wp-content/themes/wporg-photos-2024/src/style/style.scss
+++ b/source/wp-content/themes/wporg-photos-2024/src/style/style.scss
@@ -26,6 +26,17 @@
 	border-color: var(--wp--preset--color--charcoal-1) !important;
 }
 
+/* Adjust heading sizes to use "inter" style sizes. */
+.has-heading-5-font-size {
+	font-size: var(--wp--custom--heading--level-5--inter--typography--font-size) !important;
+	line-height: var(--wp--custom--heading--level-5--inter--typography--line-height) !important;
+}
+
+.has-heading-6-font-size {
+	font-size: var(--wp--custom--heading--level-6--inter--typography--font-size) !important;
+	line-height: var(--wp--custom--heading--level-6--inter--typography--line-height) !important;
+}
+
 /* Both blocks are in the local header, but only one should be shown at any given time. */
 body.blog .wp-block-wporg-local-navigation-bar .wp-block-post-title,
 body.archive .wp-block-wporg-local-navigation-bar .wp-block-post-title,

--- a/source/wp-content/themes/wporg-photos-2024/theme.json
+++ b/source/wp-content/themes/wporg-photos-2024/theme.json
@@ -9,7 +9,8 @@
 			"heading": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--inter)",
-					"lineHeight": 1.2
+					"fontWeight": "600",
+					"lineHeight": 1.4
 				}
 			},
 			"wporg/ratings-stars": {
@@ -38,22 +39,27 @@
 			"h1": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
-					"fontSize": "38px",
-					"lineHeight": "1.3",
+					"fontSize": "var(--wp--preset--font-size--heading-3)",
+					"lineHeight": "var(--wp--custom--heading--level-3--typography--line-height)",
 					"fontWeight": "400"
 				}
 			},
 			"h2": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--inter)",
-					"fontSize": "24px",
-					"lineHeight": "1.2",
-					"fontWeight": "600"
-				},
-				"spacing": {
-					"margin": {
-						"top": "var(--wp--preset--spacing--40)"
-					}
+					"fontSize": "var(--wp--custom--heading--level-4--inter--typography--font-size)",
+					"lineHeight": "var(--wp--custom--heading--level-4--inter--typography--line-height)"
+				}
+			},
+			"h3": {
+				"typography": {
+					"fontSize": "var(--wp--custom--heading--level-5--inter--typography--font-size)",
+					"lineHeight": "var(--wp--custom--heading--level-5--inter--typography--line-height)"
+				}
+			},
+			"h4": {
+				"typography": {
+					"fontSize": "var(--wp--custom--heading--level-6--inter--typography--font-size)",
+					"lineHeight": "var(--wp--custom--heading--level-6--inter--typography--line-height)"
 				}
 			}
 		}


### PR DESCRIPTION
This updates the headings across the site to use the correct "Inter Heading" levels, and with the parent-theme change, also shrinks the headings on small screens. This also cleans up some redundant settings and classes, and fixes the font-weight on the "Alternative text" label.

Fixes #24, See https://github.com/WordPress/wporg-parent-2021/pull/164

### Screenshots

<!-- If your change has a visual component, add a screenshot here. -->

| Before | After |
|--------|-------|
| ![Screen Shot 2024-12-04 at 15 11 48](https://github.com/user-attachments/assets/884c46dc-7f8c-44a0-bb4a-1d5bb5f7477a) | ![Screen Shot 2024-12-04 at 15 08 24](https://github.com/user-attachments/assets/8dad7d03-435d-43d5-b085-ae11bc3cfa7d) |
| ![Screen Shot 2024-12-04 at 15 11 58](https://github.com/user-attachments/assets/d06f0d6f-bc7b-41b8-9848-3b8880e15ef5) | ![Screen Shot 2024-12-04 at 15 08 46](https://github.com/user-attachments/assets/f503eec9-7990-4103-8254-2c71263965d6) |
| ![Screen Shot 2024-12-04 at 15 11 41](https://github.com/user-attachments/assets/5a48c73a-3b97-4e61-bdc4-6a33cee2eeb2) | ![Screen Shot 2024-12-04 at 15 09 33](https://github.com/user-attachments/assets/45cbfcda-f822-4eb6-a646-d85667a0c194) |
| ![Screen Shot 2024-12-04 at 15 11 31](https://github.com/user-attachments/assets/5d22f467-7486-4b37-be61-437868b4534f) | ![Screen Shot 2024-12-04 at 15 10 33](https://github.com/user-attachments/assets/f4568cf0-03f5-486a-94f8-aa2952dd6d7d) |

### How to test the changes in this Pull Request:

1. Set the parent theme to use https://github.com/WordPress/wporg-parent-2021/pull/164
2. Build the styles (in both repos)
3. Ensure the font sizes match the design
4. Shrink the browser to <600px, the heading sizes should drop down too.
5. In addition to the screenshots above, the headings on pages like Guidelines & photo submission should also change
